### PR TITLE
[utils] Check for 'window' in useWindowSize hook because node

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -1,5 +1,5 @@
 // External Dependencies
-import React from 'react'
+import React, { useEffect } from 'react'
 import {
   Link,
 } from 'gatsby'
@@ -24,7 +24,13 @@ const Layout = (props) => {
   } = props;
 
 
-  const isSmallScreen = useWindowSize().innerWidth < SMALL_SCREEN_SIZE;
+  let isSmallScreen;
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      useWindowSize().innerWidth < SMALL_SCREEN_SIZE;
+    }
+  }, []);
 
   const rootPath = `${__PATH_PREFIX__}/`
   let header;

--- a/src/utils/useWindowSize.js
+++ b/src/utils/useWindowSize.js
@@ -3,11 +3,13 @@ import { useState, useEffect } from 'react'
 
 // Local Functions
 function getSize() {
-  return {
-    innerHeight: window.innerHeight,
-    innerWidth: window.innerWidth,
-    outerHeight: window.outerHeight,
-    outerWidth: window.outerWidth,
+  if (window !== undefined) {
+    return {
+      innerHeight: window.innerHeight,
+      innerWidth: window.innerWidth,
+      outerHeight: window.outerHeight,
+      outerWidth: window.outerWidth,
+    };
   }
 }
 

--- a/src/utils/useWindowSize.js
+++ b/src/utils/useWindowSize.js
@@ -3,14 +3,15 @@ import { useState, useEffect } from 'react'
 
 // Local Functions
 function getSize() {
-  if (window !== undefined) {
+  if (typeof window !== 'undefined') {
     return {
       innerHeight: window.innerHeight,
       innerWidth: window.innerWidth,
       outerHeight: window.outerHeight,
       outerWidth: window.outerWidth,
-    };
+    }
   }
+  return 0;
 }
 
 // Hook Definition
@@ -22,7 +23,7 @@ function useWindowSize() {
   }
 
   useEffect(() => {
-    if (window !== undefined) {
+    if (typeof window !== 'undefined') {
       window.addEventListener('resize', handleResize)
       return () => {
         window.removeEventListener('resize', handleResize)

--- a/src/utils/useWindowSize.js
+++ b/src/utils/useWindowSize.js
@@ -20,9 +20,11 @@ function useWindowSize() {
   }
 
   useEffect(() => {
-    window.addEventListener('resize', handleResize)
-    return () => {
-      window.removeEventListener('resize', handleResize)
+    if (window !== undefined) {
+      window.addEventListener('resize', handleResize)
+      return () => {
+        window.removeEventListener('resize', handleResize)
+      }
     }
   }, [])
 


### PR DESCRIPTION
In `node` there is no concept of `window`, so we have to check for that explicitly.