### PR TITLE
fix(ci): remove package-lock.json from workflow

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Commit version bump
         run: |
-          git add package.json package-lock.json
+          git add package.json
           git commit -m "chore: update to version ${{ steps.version.outputs.RELEASE_VERSION }}"
 
       - name: Push release branch


### PR DESCRIPTION
- Remove the `package-lock.json` file from the GH workflow action. This project uses `yarn` only.