### PR TITLE
refactor(ci): move delete branch step earlier in workflow

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -41,6 +41,13 @@ jobs:
           echo "RELEASE_VERSION=$NEW_VERSION" >> $GITHUB_OUTPUT
           echo "BRANCH_NAME=release/$NEW_VERSION" >> $GITHUB_OUTPUT
 
+      - name: Delete existing release branch if it exists
+        run: |
+          if git ls-remote --exit-code origin "refs/heads/${{ steps.version.outputs.BRANCH_NAME }}"; then
+            echo "Branch ${{ steps.version.outputs.BRANCH_NAME }} already exists on remote. Deleting it..."
+            git push origin :"${{ steps.version.outputs.BRANCH_NAME }}"
+          fi
+
       - name: Create release branch
         run: |
           git checkout -b ${{ steps.version.outputs.BRANCH_NAME }}
@@ -53,13 +60,6 @@ jobs:
       - name: Push release branch
         run: |
           git push origin ${{ steps.version.outputs.BRANCH_NAME }}
-
-      - name: Delete existing release branch if it exists
-        run: |
-          if git ls-remote --exit-code origin "refs/heads/${{ steps.version.outputs.BRANCH_NAME }}"; then
-            echo "Branch ${{ steps.version.outputs.BRANCH_NAME }} already exists on remote. Deleting it..."
-            git push origin :"${{ steps.version.outputs.BRANCH_NAME }}"
-          fi
 
       - name: Create Pull Request
         uses: actions/github-script@v7


### PR DESCRIPTION
- Since we were going to check if the branch existed _after_ trying to push the branch, this was always going to fail.
  - Side note: even if the Agentic AI tells you something, make sure you read the code!