### PR TITLE
refactor(ci): update pr date to 2020

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -77,7 +77,7 @@ jobs:
             } catch (error) {
               console.log('No previous release found, will include all merged PRs');
               // Set to a very old date to include all PRs if no previous release
-              lastReleaseDate = new Date('2015-01-01');
+              lastReleaseDate = new Date('2020-01-01');
             }
 
             // Get all merged PRs


### PR DESCRIPTION
The date for 2015 is pretty far back. Let skip ahead to 2020 to reduce the number of PRs to sift through.